### PR TITLE
Guard visual font setup without graphics context

### DIFF
--- a/forester/java/src/org/forester/archaeopteryx/TreePanel.java
+++ b/forester/java/src/org/forester/archaeopteryx/TreePanel.java
@@ -4483,7 +4483,7 @@ public final class TreePanel extends JPanel implements ActionListener, MouseWhee
             }
             boolean use_vis = false;
             final Graphics2D g = (Graphics2D) getGraphics();
-            if (getControlPanel().isUseVisualStyles()) {
+            if ((g != null) && getControlPanel().isUseVisualStyles()) {
                 use_vis = setFont(g, node, false);
             }
             if (!use_vis) {


### PR DESCRIPTION
`TreePanel` uses `getGraphics()` while calculating text width for tree rendering. Swing can return `null` from `Component.getGraphics()` before a component has a graphics context. This guard keeps the existing default-font fallback in that case.